### PR TITLE
GitHub theme support

### DIFF
--- a/src/css/gh-file-viewer.css
+++ b/src/css/gh-file-viewer.css
@@ -11,13 +11,17 @@ body.gh-file-viewer .container {
   flex: 1;
   min-width: 400px;
   margin-right: 20px;
-  background-color: #fff;
-  border: 1px solid #e1e4e8;
+  background-color: var(--color-bg-canvas);
+  border: 1px solid var(--color-border-primary);
   border-radius: 2px;
 }
 
 .js-diff-progressive-container {
   flex: 1 1 100%;
+}
+
+.file-info {
+  color: var(--color-text-primary);
 }
 
 .file-nav-tree {
@@ -51,14 +55,15 @@ body.gh-file-viewer .container {
 .file-tree__label {
   display: block;
   padding: 3px;
+  color: var(--color-text-primary);
 }
 
 .file-tree__label:hover {
-  background-color: #f7f7f7;
+  background-color: var(--color-bg-secondary);
 }
 
 .file-tree__label.active {
-  background-color: #f3f8ff;
+  background-color: var(--color-bg-tertiary);
   font-weight: bold;
 }
 
@@ -80,26 +85,22 @@ body.gh-file-viewer .container {
   color: #599659;
 }
 
-.file-tree__label {
-  color: #717171
-}
-
 .file-tree__label--icon {
   margin-bottom: -1px;
 }
 
 .file-tree__label--icon--rb {
-  color: #d48484
+  color: #d48484;
 }
 
 .file-tree__label--icon--erb {
-  color: #a470bd
+  color: #a470bd;
 }
 
 .file-tree__label--icon--js {
-  color: #70bd74
+  color: #70bd74;
 }
 
 .file-tree__label--icon--scss {
-  color: #709fbd
+  color: #709fbd;
 }


### PR DESCRIPTION
### Purpose

Use the GitHub theme colors for text and backgrounds for dark mode support

### Before

<img width="1669" alt="Comparing derek-meulmeester:master DavidRinkoff:patch-1 · derek-meulmeester:gh-file-viewer 2021-04-16 16-56-00" src="https://user-images.githubusercontent.com/18235607/115082988-bf9e2580-9ed4-11eb-904b-55c96cee6afd.png">

### After

<img width="1651" alt="Comparing derek-meulmeester:master DavidRinkoff:patch-1 · derek-meulmeester:gh-file-viewer 2021-04-16 16-55-15" src="https://user-images.githubusercontent.com/18235607/115083000-c462d980-9ed4-11eb-9fa8-8c5a47771a6d.png">

<img width="1674" alt="Comparing derek-meulmeester:master DavidRinkoff:patch-1 · derek-meulmeester:gh-file-viewer 2021-04-16 16-55-29" src="https://user-images.githubusercontent.com/18235607/115083008-c5940680-9ed4-11eb-9165-9667bdd9cde0.png">
